### PR TITLE
Use local config override instead of replacing config

### DIFF
--- a/install/etc/s6/services/10-nginx/run
+++ b/install/etc/s6/services/10-nginx/run
@@ -82,7 +82,7 @@ if [ ! -f /tmp/state/10-nginx ]; then
 	if [ ! -f /www/ssp/index.php ] ; then
 	   echo "Self Service Password Not Found, Downloading and setting up......"
 	   mkdir -p /www/ssp/
-	   git clone https://github.com/ltb-project/self-service-password /www/ssp
+	   git clone --depth 1 https://github.com/ltb-project/self-service-password /www/ssp
 	   echo "Insalled... Please visit the website.."
 	   chown nginx:www-data /www/ssp
 	fi

--- a/install/etc/s6/services/10-nginx/run
+++ b/install/etc/s6/services/10-nginx/run
@@ -147,7 +147,7 @@ if [ ! -f /tmp/state/10-nginx ]; then
 	sed -i -e "s/<RECAPTCHA_SIZE>/$RECAPTCHA_SIZE/g" /assets/ssp/config.inc.php.template
 	sed -i -e "s/<DEFAULT_ACTION>/$DEFAULT_ACTION/g" /assets/ssp/config.inc.php.template
 
-	cp -R /assets/ssp/config.inc.php.template /www/ssp/conf/config.inc.php
+	cp -R /assets/ssp/config.inc.php.template /www/ssp/conf/config.inc.local.php
 
 	### Force Reset Permissions for Security
 	chown -R nginx:www-data /www/ssp


### PR DESCRIPTION
Hi,

This change copies the generated config to `config.inc.local.php` so that it is included by the base config and overrides default variables, rather than act as a complete config on its own.

This fixes warnings that appear when there are new variables introduced that aren't in the templated config file (e.g. `$use_pwnedpasswords`).

Also does a shallow git clone, as the entire git history isn't really needed in the docker image.