### PR TITLE
install/etc/s6/services/10-nginx/run, fix in-place update of $reset_url variable

### DIFF
--- a/install/etc/s6/services/10-nginx/run
+++ b/install/etc/s6/services/10-nginx/run
@@ -73,7 +73,7 @@ if [ ! -f /tmp/state/10-nginx ]; then
 	SKIP_MAIL=${SKIP_MAIL:-'false'}
 
 	if [[ ${IS_BEHIND_PROXY} == true  ]]; then
-		 sed 's/#\$reset_url = /\$reset_url = /g' /assets/ssp/config.inc.php.template
+		 sed -i 's/#\$reset_url = /\$reset_url = /g' /assets/ssp/config.inc.php.template
 	fi
 
 	sed -i -e "s|<LDAP_SERVER>|$LDAP_SERVER|g" /assets/ssp/config.inc.php.template


### PR DESCRIPTION
it seems the sed in-place parameter got lost on updating `install/etc/s6/services/10-nginx/run` while fixing #11 :)

btw. with it the generated URLs are then correctly set to `HTTP_HOST` and `HTTP_X_FORWARDED_PROTO` for me