### PR TITLE
Fix  setting SITE_URL

### DIFF
--- a/install/etc/cont-init.d/30-self-service-password
+++ b/install/etc/cont-init.d/30-self-service-password
@@ -158,9 +158,9 @@ if [ "$SETUP_TYPE" = "AUTO" ]; then
     ## Reverse proxy Setup
     if [ "$IS_BEHIND_PROXY" = "true" ]; then
     	 sed -i 's/#\$reset_url = /\$reset_url = /g' ${NGINX_WEBROOT}/conf/config.inc.php
-         if [ -n "${SITE_URL}"  ]; then
-            sed -i -r 's|\$reset_url = .*|\$reset_url = "${SITE_URL}";|g' ${NGINX_WEBROOT}/conf/config.inc.php
-         fi
+       if [ -n "${SITE_URL}"  ]; then
+         update_config reset_url ${SITE_URL}
+       fi
     fi
 
     ### Set Debug Mode


### PR DESCRIPTION
Seems like it was never working because `'` (should be `"`)
Used function to simplify it..

Would be nice to actually add function for enabling option.. That would simplify that file further..

Something like
```
uncomment_option() {
    print_debug "Uncommenting '\$${1}'"
    sed -i -e "s/#\$${1} = /\$${1} = /g" ${NGINX_WEBROOT}/conf/config.inc.php
}
```