### PR TITLE
Do not fallback to default logo on undefined

### DIFF
--- a/install/assets/functions/30-self-service-password
+++ b/install/assets/functions/30-self-service-password
@@ -29,7 +29,6 @@ LDAP_STARTTLS=${LDAP_STARTTLS:-false}
 LOG_LOCATION=${LOG_LOCATION:-"/www/logs/self-service-password/"}
 LOG_RESET=${LOG_RESET:-"reset.log"}
 LOGIN_FORBIDDEN_CHARACTERS=${LOGIN_FORBIDDEN_CHARACTERS:-"*()\&\|"}
-LOGO=${LOGO:-"images/ltb-logo.png"}
 MAIL_CHARSET=${MAIL_CHARSET:-"utf-8"}
 MAIL_CONTENTTYPE=${MAIL_CONTENTTYPE:-"text/plain"}
 MAIL_FROM=${MAIL_FROM:-"admin@example.com"}


### PR DESCRIPTION
Currently it is not possible to set it to an empty value, like `LOGO: ""`, that way it will be possible to hide it by default. Call to `update_config logo ${LOGO}` properly set it to an empty value if $LOGO is undefined.