### PR TITLE
Add support for PASSWORD_COMPLEXITY / $pwd_complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Be sure to view the following repositories to understand all the customizable op
 | `PASSWORD_MIN_LOWERCASE`        | Minimal lower characters.                                                                                                | `0` (unchecked). |
 | `PASSWORD_MIN_SPECIAL`          | Minimal special characters.                                                                                              | `0` (unchecked). |
 | `PASSWORD_MIN_UPPERCASE`        | Minimal upper characters.                                                                                                | `0` (unchecked). |
+| `PASSWORD_COMPLEXITY`           | Minimum number of different classes of characters.                                                                       | `0` (unchecked). |
 | `PASSWORD_NO_REUSE`             | Dont reuse the same password as currently.                                                                               | `true`.          |
 | `PASSWORD_NO_SPECIAL_ENDS`      | Dont allow special characters at start and end of password                                                               | `false`          |
 | `PASSWORD_SHOW_POLICY_POSITION` | Position of password policy constraints message `above` `below`                                                          | `above`          |

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       - PASSWORD_MIN_DIGIT=0
     # Minimal special characters
       - PASSWORD_MIN_SPECIAL=0
+    # Minimum number of different classes of characters
+      - PASSWORD_COMPLEXITY=0
     # Dont reuse the same password as currently
       - PASSWORD_NO_REUSE=true
     # Definition of special characters

--- a/install/etc/cont-init.d/30-self-service-password
+++ b/install/etc/cont-init.d/30-self-service-password
@@ -60,6 +60,7 @@ if [ "${SETUP_TYPE,,}" = "auto" ]; then
     update_config_noquote pwd_min_upper "${PASSWORD_MIN_UPPERCASE}"
     update_config_noquote pwd_min_digit "${PASSWORD_MIN_DIGIT}"
     update_config_noquote pwd_min_special "${PASSWORD_MIN_SPECIAL}"
+    update_config_noquote pwd_complexity "${PASSWORD_COMPLEXITY}"
     update_config pwd_special_chars "${PASSWORD_SPECIAL_CHARACTERS}"
     update_config_noquote pwd_no_reuse "${PASSWORD_NO_REUSE}"
     update_config_noquote pwd_diff_login "${PASSWORD_DIFFERENT_LOGIN}"


### PR DESCRIPTION
It was already included in the defaults, so it only needed to be actually set. I also added it to README and the compose example.

Fixes #57.