### PR TITLE
Update README - unencrypted SMTP connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Be sure to view the following repositories to understand all the customizable op
 | `SMTP_KEEPALIVE`          | SMTP Keepalive                                                                     | `false`                 |
 | `SMTP_PASS`               | SMTP password.                                                                     |                         |
 | `SMTP_PORT`               | SMTP port.                                                                         | `587`                   |
-| `SMTP_SECURE_TYPE`        | SMTP secure type to use. `ssl` or `tls`.                                           | `tls`                   |
+| `SMTP_SECURE_TYPE`        | SMTP secure type to use. `ssl` or `tls`. Use `false` for unencrypted connections.  | `tls`                   |
 | `SMTP_TIMEOUT`            | SMTP Timeout in seconds                                                            | `30`                    |
 | `SMTP_USER`               | SMTP user.                                                                         |                         |
 


### PR DESCRIPTION
## Description
PR is adding information to README how to adjust `SMTP_SECURE_TYPE` parameter in case of insecure SMTP connection. There was no such information in current version of README.

## Tests
Tested with success on following environment:
* kubernetes 1.27.0
* docker.io/boky/postfix:v3.6.1-ubuntu
* docker.io/tiredofit/self-service-password:5.2.3