### PR TITLE
Add support for Twilio SMS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG DISTRO="alpine"
 FROM docker.io/tiredofit/nginx-php-fpm:${PHP_VERSION}-${DISTRO}
 LABEL maintainer="Dave Conroy (github.com/tiredofit)"
 
-ENV SSP_VERSION=1.3 \
+ENV SSP_VERSION=1.5.3 \
     PHP_ENABLE_LDAP=TRUE \
     PHP_ENABLE_CREATE_SAMPLE_PHP=FALSE \
     NGINX_SITE_ENABLED=ssp \

--- a/README.md
+++ b/README.md
@@ -231,6 +231,15 @@ Be sure to view the following repositories to understand all the customizable op
 | `SMS_TOKEN_LENGTH`           | How many digits for a SMS Code   | `6`                                     |
 | `SMS_TRUNCATE_NUMBER_LENGTH` | How many characters for above    | `10`                                    |
 | `SMS_TRUNCATE_NUMBER`        | Truncate Characters of number    | `false`                                 |
+| `TWILIO_SID`                 | Twilio SID for API access        | None                                    |
+| `TWILIO_AUTH_TOKEN`          | Twilio auth token for API access | None                                    |
+| `TWILIO_OUTGOING_NUMBER`     | Number to send SMS from          | None                                    |
+
+Twilio setup:
+
+Set `SMS_API_LIB` to `lib/smsapi-twilio.inc.php`.
+
+You can get the TWILIO_SID and TWILIO_AUTH_TOKEN from [the Twilio console](https://www.twilio.com/console), and the TWILIO_OUTGOING_NUMBER from [the Twilio phone number database](https://www.twilio.com/console/phone-numbers/search).
 
 #### SSH Settings
 

--- a/install/assets/functions/30-self-service-password
+++ b/install/assets/functions/30-self-service-password
@@ -9,3 +9,12 @@ update_config_noquote() {
     print_debug "Updating \$${1} with value '${2}"
     sed -i -e "s#${1} = .*#${1} = ${2};#g" ${NGINX_WEBROOT}/conf/config.inc.php
 }
+
+add_to_config() {
+    if [[ -z "${2}" ]] ; then
+        print_debug "Not adding '\$${1}', no value provided"
+    else
+        print_debug "Adding '\$${1}' with value '${2}"
+        echo "${1} = \"${2}\"" >> ${NGINX_WEBROOT}/conf/config.inc.php
+    fi
+}

--- a/install/etc/cont-init.d/30-self-service-password
+++ b/install/etc/cont-init.d/30-self-service-password
@@ -155,6 +155,11 @@ if [ "${SETUP_TYPE,,}" = "auto" ]; then
     update_config recaptcha_size "${RECAPTCHA_SIZE}"
     update_config_noquote recaptcha_request_method "${RECAPTCHA_REQUEST_METHOD}"
 
+    ## Twilio
+    add_to_config twilio_sid "${TWILIO_SID}"
+    add_to_config twilio_auth_token "${TWILIO_AUTH_TOKEN}"
+    add_to_config twilio_outgoing_number "${TWILIO_OUTGOING_NUMBER}"
+
     ## Default action
     update_config default_action "${DEFAULT_ACTION}"
 


### PR DESCRIPTION
Upstream now includes a Twilio example script.
* Add support for adding new values to the config.inc.php.
* Add variables for the Twilio example script.